### PR TITLE
Set meta-spec to version 2, so that the repository info will be handled right

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
     dist              => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Mojo-Webqq-* MANIFEST' },
     META_MERGE => {
+        'meta-spec' => { version => 2 },
         resources => {     
             repository=>{
                 type    => 'git',


### PR DESCRIPTION
Hi,

The `META_MERGE` fields in `Makefile.PL` were version 2 style, but `meta-spec` wasn't set to version 2. As a result the META files didn't contain the github repo.

This pull request fixes that.

Cheers,
Neil
