### PR TITLE
添加MacOS的支持。修改Windows的OS名称判断

### DIFF
--- a/lib/Mojo/Webqq/Plugin/ShowQRcode.pm
+++ b/lib/Mojo/Webqq/Plugin/ShowQRcode.pm
@@ -9,14 +9,20 @@ $client->on(input_qrcode=>sub
                {
                  my($client,$qrcode_path) = @_;
                  my $command;
-                 if($^O=~/win/i)
+                 if($^O=~/^MSWin32/i) # Windows
                  {
    	                $command="start $qrcode_path";
    	                eval(system($command));
-                    $self->error($@) if $@;
+                    $client->error($@) if $@;
                  }
-                 elsif($^O=~/linux/i)
+                 elsif($^O=~/^linux/i) # Linux
                  {
+                 }
+                 elsif($^O=~/^darwin/i) # Mac OS X
+                 {
+                    $command="open $qrcode_path";
+                    eval(system($command));
+                    $client->error($@) if $@;
                  }
               }
         );


### PR DESCRIPTION
1. 添加了Mac OSX的系统名称判断，增加在Mac OSX下打开二维码的命令。
2. 修改了原判断Windows系统的命令，改为MSWin32，因为和Mac OSX的名称有重叠(win和darwin)。
3. 修改原来$self变成$client。