### PR TITLE
Fix: 如果同时设定了is_need_at和keyword, 会导致判定出错不会执行下方命令. 现在强制判断, 只有is_need_at…

### DIFF
--- a/lib/Mojo/Webqq/Plugin/SmartReply.pm
+++ b/lib/Mojo/Webqq/Plugin/SmartReply.pm
@@ -31,7 +31,7 @@ sub call{
         my $sender_nick = $msg->sender->displayname;
         my $user_nick = $msg->receiver->displayname;
         return if $is_need_at and $msg->type eq "group_message" and !$msg->is_at;
-        if(ref $data->{keyword} eq "ARRAY"){
+        if(!$is_need_at and ref $data->{keyword} eq "ARRAY"){
             return if not first { $msg->content =~ /\Q$_\E/} @{$data->{keyword}};
         }
         if($msg->type eq 'group_message'){


### PR DESCRIPTION
如果同时设定了is_need_at和keyword, 会导致判定出错不会执行下方命令. 现在强制判断, 只有is_need_at为0的时候才检查keyword. 防止不明群众二者都设置导致功能失效.