### PR TITLE
修改mipush通知栏发送参数问题

### DIFF
--- a/lib/Mojo/Webqq/Plugin/MiPush.pm
+++ b/lib/Mojo/Webqq/Plugin/MiPush.pm
@@ -84,20 +84,19 @@ sub call {
             }
 			);
 		} else {		
-			$client->http_post(
-                $client->gen_url($api_url,
-                    pass_through => 0,
-                    registration_id => Mojo::Util::url_escape($registration_id),
-                    restricted_package_namee => Mojo::Util::url_escape($pkgname),
-                    'extra.notify_effect' => 2,
-                    'extra.intent_uri' => $qq_package_url,
-                    title => Mojo::Util::url_escape($title),
-                    description => Mojo::Util::url_escape($message),
-                    payload => Mojo::Util::url_escape($message),
-                ),
-				{
-                    'Authorization'=>"key=$api_key",
-				    json=>1
+			$client->http_post($api_url, 
+				{'Authorization'=>"key=$api_key",
+				json=>1
+				},
+				form=>{
+                pass_through => 0,
+                registration_id => $registration_id,
+                restricted_package_namee => $pkgname,
+				'extra.notify_effect' => 2,
+				'extra.intent_uri' => $qq_package_url,
+				title => $title,
+				description => $message,
+                payload => $message,
 				},
 				sub{
                 my $json = shift;


### PR DESCRIPTION
'extra.notify_effect'、'extra.intent_uri'
已知问题，在手机未运行QQ时会拉起QQ，而在已运行QQ时，会杀掉QQ，目前看是QQ本身的问题。